### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/database/database.dart
+++ b/lib/src/database/database.dart
@@ -50,7 +50,8 @@ class Database {
 
         response = await request.close();
         _logger.fine('response status code: ${response.statusCode}');
-        responsePayload = await response.transform(utf8.decoder).join();
+        responsePayload =
+            await response.cast<List<int>>().transform(utf8.decoder).join();
         _logger.fine('response payload:\n$responsePayload');
 
         responseJson = json.decode(responsePayload);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pkgraph
-version: 2.1.0
+version: 2.1.0+1
 description: A tool for studying and visualizing Dart package dependencies.
 author: George Lesica <george@lesica.com>
 homepage: https://github.com/glesica/pkgraph


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900